### PR TITLE
Send email notifications for new alerts

### DIFF
--- a/emergency_alert_system/alerts/tests.py
+++ b/emergency_alert_system/alerts/tests.py
@@ -1,3 +1,28 @@
-from django.test import TestCase
+from django.test import TestCase, override_settings
+from django.urls import reverse
+from rest_framework.test import APIClient
+from django.core import mail
 
-# Create your tests here.
+
+class AlertEmailTest(TestCase):
+    """Ensure an email is sent when an alert is created."""
+
+    def setUp(self):
+        self.client = APIClient()
+
+    @override_settings(
+        ALERT_RECIPIENTS=['test@example.com'],
+        EMAIL_BACKEND='django.core.mail.backends.locmem.EmailBackend',
+        DEFAULT_FROM_EMAIL='noreply@example.com',
+    )
+    def test_email_sent_on_alert_creation(self):
+        payload = {
+            'title': 'Test',
+            'message': 'Test message',
+            'latitude': 1.0,
+            'longitude': 2.0,
+        }
+        response = self.client.post(reverse('create-alert'), payload, format='json')
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(len(mail.outbox), 1)
+        self.assertIn('New Alert: Test', mail.outbox[0].subject)

--- a/emergency_alert_system/alerts/views.py
+++ b/emergency_alert_system/alerts/views.py
@@ -2,6 +2,8 @@ from rest_framework import generics
 from .models import Alert
 from .serializers import AlertSerializer
 from rest_framework.response import Response
+from django.conf import settings
+from django.core.mail import send_mail
 import math
 
 class CreateAlertView(generics.CreateAPIView):
@@ -10,6 +12,18 @@ class CreateAlertView(generics.CreateAPIView):
     """
     queryset = Alert.objects.all()
     serializer_class = AlertSerializer
+
+    def perform_create(self, serializer):
+        """Send an email notification after creating an alert."""
+        alert = serializer.save()
+        recipients = getattr(settings, 'ALERT_RECIPIENTS', [])
+        if recipients:
+            send_mail(
+                subject=f"New Alert: {alert.title}",
+                message=alert.message,
+                from_email=settings.DEFAULT_FROM_EMAIL,
+                recipient_list=recipients,
+            )
 
 class ListNearbyAlertsView(generics.ListAPIView):
     """

--- a/emergency_alert_system/emergency_alert_system/settings.py
+++ b/emergency_alert_system/emergency_alert_system/settings.py
@@ -139,3 +139,9 @@ SPECTACULAR_SETTINGS = {
     'VERSION': '1.0.0',
     'SERVE_INCLUDE_SCHEMA': False,
 }
+
+# Email settings
+EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
+DEFAULT_FROM_EMAIL = 'alerts@example.com'
+# Recipients who should be notified whenever a new alert is created
+ALERT_RECIPIENTS = ['alerts@example.com']


### PR DESCRIPTION
## Summary
- configure email backend and recipients for alert notifications
- send an email whenever a new alert is created
- add a test covering alert email notifications

## Testing
- `python emergency_alert_system/manage.py test 2>&1 | head -n 20` *(fails: No module named 'django')*
- `pip install Django==5.2.3 djangorestframework drf-spectacular` *(fails: Could not find a version that satisfies the requirement Django==5.2.3)*

------
https://chatgpt.com/codex/tasks/task_e_68935c75a660832f9acfc0be8e32f96e