### PR TITLE
Add email and in-app notifications for saved contacts

### DIFF
--- a/emergency_alert_system/alerts/admin.py
+++ b/emergency_alert_system/alerts/admin.py
@@ -1,7 +1,8 @@
 from django.contrib import admin
 
-from .models import Alert, UserProfile, Contact
+from .models import Alert, UserProfile, Contact, Notification
 
 admin.site.register(Alert)
 admin.site.register(UserProfile)
 admin.site.register(Contact)
+admin.site.register(Notification)

--- a/emergency_alert_system/alerts/migrations/0003_alert_created_by_notification.py
+++ b/emergency_alert_system/alerts/migrations/0003_alert_created_by_notification.py
@@ -1,0 +1,35 @@
+from django.conf import settings
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('alerts', '0002_userprofile_contact'),
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='alert',
+            name='created_by',
+            field=models.ForeignKey(
+                on_delete=models.CASCADE,
+                related_name='alerts',
+                to=settings.AUTH_USER_MODEL,
+                default=1,
+            ),
+            preserve_default=False,
+        ),
+        migrations.CreateModel(
+            name='Notification',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('message', models.CharField(max_length=255)),
+                ('created_at', models.DateTimeField(auto_now_add=True)),
+                ('read', models.BooleanField(default=False)),
+                ('alert', models.ForeignKey(on_delete=models.CASCADE, related_name='notifications', to='alerts.alert')),
+                ('user', models.ForeignKey(on_delete=models.CASCADE, related_name='notifications', to=settings.AUTH_USER_MODEL)),
+            ],
+        ),
+    ]

--- a/emergency_alert_system/alerts/models.py
+++ b/emergency_alert_system/alerts/models.py
@@ -7,6 +7,11 @@ class Alert(models.Model):
     message = models.TextField()
     latitude = models.FloatField()
     longitude = models.FloatField()
+    created_by = models.ForeignKey(
+        settings.AUTH_USER_MODEL,
+        on_delete=models.CASCADE,
+        related_name='alerts',
+    )
     timestamp = models.DateTimeField(auto_now_add=True)
 
     def __str__(self) -> str:
@@ -32,3 +37,18 @@ class Contact(models.Model):
 
     def __str__(self) -> str:
         return f"{self.name} ({self.user.email})"
+
+
+class Notification(models.Model):
+    user = models.ForeignKey(
+        settings.AUTH_USER_MODEL,
+        on_delete=models.CASCADE,
+        related_name='notifications',
+    )
+    alert = models.ForeignKey(Alert, on_delete=models.CASCADE, related_name='notifications')
+    message = models.CharField(max_length=255)
+    created_at = models.DateTimeField(auto_now_add=True)
+    read = models.BooleanField(default=False)
+
+    def __str__(self) -> str:
+        return f"Notification for {self.user.email}: {self.message}"

--- a/emergency_alert_system/alerts/serializers.py
+++ b/emergency_alert_system/alerts/serializers.py
@@ -1,13 +1,14 @@
 from django.contrib.auth import get_user_model
 from rest_framework import serializers
 
-from .models import Alert, UserProfile, Contact
+from .models import Alert, UserProfile, Contact, Notification
 
 
 class AlertSerializer(serializers.ModelSerializer):
     class Meta:
         model = Alert
         fields = '__all__'
+        read_only_fields = ('created_by', 'timestamp')
 
 
 class UserProfileSerializer(serializers.ModelSerializer):
@@ -45,3 +46,9 @@ class ContactSerializer(serializers.ModelSerializer):
     class Meta:
         model = Contact
         fields = ('id', 'name', 'phone', 'email')
+
+
+class NotificationSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Notification
+        fields = ('id', 'alert', 'message', 'created_at', 'read')

--- a/emergency_alert_system/alerts/urls.py
+++ b/emergency_alert_system/alerts/urls.py
@@ -6,6 +6,7 @@ from .views import (
     RegisterView,
     LoginView,
     ContactListCreateView,
+    NotificationListView,
 )
 
 urlpatterns = [
@@ -15,4 +16,5 @@ urlpatterns = [
     path('auth/register/', RegisterView.as_view(), name='register'),
     path('auth/login/', LoginView.as_view(), name='login'),
     path('contacts/', ContactListCreateView.as_view(), name='contacts'),
+    path('notifications/', NotificationListView.as_view(), name='notifications'),
 ]


### PR DESCRIPTION
## Summary
- track alert creators and notify their saved contacts via email
- create in-app notifications for contacted users within 100m
- expose notification listing endpoint

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*